### PR TITLE
appstream: Fix metainfo file

### DIFF
--- a/data/fonts-installer.metainfo.xml
+++ b/data/fonts-installer.metainfo.xml
@@ -1,17 +1,16 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
+  <id>io.github.HarveyDevel.fonts-installer</id>
   <launchable type="desktop-id">fonts-installer.desktop</launchable>
   <name>fonts-installer</name>
-  <summary>A Qt6 GUI tool to install mscorefonts on Linux.</summary>
-  <metadata_license>Apache-2.0</metadata_license>
+  <summary>A Qt6 GUI tool to install mscorefonts on Linux</summary>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
   <url type="homepage">https://github.com/HarveyDevel/fonts-installer</url>
   <url type="bugtracker">https://github.com/HarveyDevel/fonts-installer/issues</url>
   <description>
     <p>A Qt6 GUI tool to install mscorefonts on Linux.</p>
-    
-    Available fonts:
+    <p>Available fonts:</p>
     <ul>
       <li>Andale Mono</li>
       <li>Arial (regular, bold, italic, bold italic)</li>


### PR DESCRIPTION
The AppStream metainfo file has some issues that prevent it from being
used in software centers:

- Extra newline at the start of the file
- Metainfo license was not permissible
- ID was missing
- Minor lints for summary and description

There is still a remaining issue in that `appstreamcli` cannot find the icon for the application.
